### PR TITLE
Fix duplicate chat input

### DIFF
--- a/src/chimera/custom_chat/custom_chat.cpp
+++ b/src/chimera/custom_chat/custom_chat.cpp
@@ -584,10 +584,11 @@ namespace Chimera {
     }
 
     static void on_chat_input() noexcept {
-        struct alignas(std::uint16_t) key_input {
+        struct key_input {
             std::uint8_t modifier;
             std::uint8_t character;
             std::uint8_t key_code;
+            std::uint8_t unknown; // definitely set to different values but meaning is unclear
         }; static_assert(sizeof(key_input) == sizeof(std::uint32_t)); // 4-byte strides
         
         static key_input    *input_buffer = nullptr; // array of size 0x40
@@ -600,7 +601,7 @@ namespace Chimera {
 
         // Handle keyboard input if we have the chat input open
         if(chat_input_open) {
-            const auto& [modifier, character, key_code] = input_buffer[*input_count];
+            const auto& [modifier, character, key_code, input_unknown] = input_buffer[*input_count];
             // Special key pressed
             if(character == 0xFF) {
                 if(key_code == 0) {


### PR DESCRIPTION
This PR aims to fix a bug with chat: if two keys are pressed simultaneously, chimera replays the first input instead.
The issue is that Halo stores an array of buffered input (up to 64), but chimera was only ever referencing the first element of the array.
_static bool ignore_next_key_ was a symptom of this, as entering backspace would result in input in the following order:

1. character = 0xFF, key_code = 0x1D
2. character = 0x08, key_code = 0xFF

Since the second input replays the first, every time the user hit backspace chimera would see two special backspace characters, thus requiring that every other backspace chimera saw be dropped.
Therefore, this PR also makes changes to prevent control characters (as determined by `std::iscntrl`) from being inserted into `chat_input_buffer` and removes the `ignore_next_key` adjustment.