### PR TITLE
Display wider range of characters in custom chat

### DIFF
--- a/src/chimera/custom_chat/custom_chat.cpp
+++ b/src/chimera/custom_chat/custom_chat.cpp
@@ -542,12 +542,15 @@ namespace Chimera {
 
         // Get player name
         auto player_name = u16_to_u8(player_info.name);
+        // Re-encode from UTF-16 to UTF-8, as wcrtomb is producing unreliable results
+        std::string message_u8 = u16_to_u8(message);
 
         // Format a message
         char entire_message[MAX_MESSAGE_LENGTH];
-        std::snprintf(entire_message, sizeof(entire_message) - 1, format_to_use, name_color_to_use, player_name.c_str(), message);
+        std::snprintf(entire_message, sizeof(entire_message) - 1, format_to_use, name_color_to_use, player_name.c_str(), message_u8.c_str());
 
-        // Initialize
+        // Initialize; any UTF-8 codepoints that were cut off by the format will be replaced by 
+        // U+FFFD (or other appropriate character) as detailed in the documentation for MultiByteToWideChar.
         initialize_chat_message(chat_message, entire_message, color_to_use);
         add_message_to_array(chat_messages, chat_message);
 

--- a/src/chimera/localization/language/0
+++ b/src/chimera/localization/language/0
@@ -28,9 +28,9 @@ chimera_custom_chat_to_vehicle                                                  
 chimera_color_red                                                               red
 chimera_color_blue                                                              blue
 
-chimera_custom_chat_from_all                                                    ^%s%s^;^;: %S
-chimera_custom_chat_from_team                                                   ^%s%s^;^; (team): %S
-chimera_custom_chat_from_vehicle                                                ^%s%s^;^; (vehicle): %S
+chimera_custom_chat_from_all                                                    ^%s%s^;^;: %s
+chimera_custom_chat_from_team                                                   ^%s%s^;^; (team): %s
+chimera_custom_chat_from_vehicle                                                ^%s%s^;^; (vehicle): %s
 
 chimera_category_bookmark                                                       bookmark
 chimera_category_controller                                                     controller

--- a/src/chimera/localization/language/1
+++ b/src/chimera/localization/language/1
@@ -14,9 +14,9 @@ chimera_custom_chat_to_all                                                      
 chimera_custom_chat_to_team                                                     Equipo
 chimera_custom_chat_to_vehicle                                                  Vehículo
 
-chimera_custom_chat_from_all                                                    ^%s%s^;^;: %S
-chimera_custom_chat_from_team                                                   ^%s%s^;^; (equipo): %S
-chimera_custom_chat_from_vehicle                                                ^%s%s^;^; (vehículo): %S
+chimera_custom_chat_from_all                                                    ^%s%s^;^;: %s
+chimera_custom_chat_from_team                                                   ^%s%s^;^; (equipo): %s
+chimera_custom_chat_from_vehicle                                                ^%s%s^;^; (vehículo): %s
 
 chimera_category_bookmark                                                       bookmark
 chimera_category_core                                                           esencial

--- a/src/chimera/localization/language/2
+++ b/src/chimera/localization/language/2
@@ -11,9 +11,9 @@ chimera_custom_chat_to_all                                                      
 chimera_custom_chat_to_team                                                     ^5Vaaap^;
 chimera_custom_chat_to_vehicle                                                  ^5Vaaaaaap^;
 
-chimera_custom_chat_from_all                                                    ^%s%s^;^;: %S
-chimera_custom_chat_from_team                                                   ^%s%s^;^; (^5vaaap^;): %S
-chimera_custom_chat_from_vehicle                                                ^%s%s^;^; (^5vaaaaaap^;): %S
+chimera_custom_chat_from_all                                                    ^%s%s^;^;: %s
+chimera_custom_chat_from_team                                                   ^%s%s^;^; (^5vaaap^;): %s
+chimera_custom_chat_from_vehicle                                                ^%s%s^;^; (^5vaaaaaap^;): %s
 
 chimera_command_error_no_such_category_or_command                               VAP! *flicks away %s with tailfin*
 chimera_language_command_error_invalid_language                                 VAP! *flicks away %s with tailfin*


### PR DESCRIPTION
This PR applies the same treatment given to names in custom chat to the message content (b906564).
The localization format strings were using the `%S` format specifier, which refers to `wcrtomb()` for the character conversion and is dependent on the currently installed locale (by default, the classic C locale). This could cause a number of wide characters to be recognized as invalid under the locale, causing `wcrtomb()` to fail.
The changes: `message` is encoded under UTF-8 (using `u16_to_u8()` to be consistent with the displayed player name) for the format and the localization strings have been adjusted appropriately.

Sample: https://i.imgur.com/JZ36Nfrh.jpg